### PR TITLE
Fixed wrong references in GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Report a bug in the E6C tool
+about: Report a bug in the blog platform
 title: "[BUG]"
 labels: bug
 assignees: ''
@@ -50,7 +50,7 @@ You can read more about issue submission guidelines here: https://repl.it/@niche
 
 ## 🧩 Your Environment
 
-**E6C Version:**
+**Blog Version:**
 <pre><code>
 <!-- run `poetry version` and paste output below -->
 <!-- ✍️-->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Suggest a feature for E6C tool
+about: Suggest a feature for blog platform
 title: "[FEATURE]"
 labels: enhancement
 assignees: ''


### PR DESCRIPTION
This is now correctly referencing the blog platform instead.

Fixes #7 